### PR TITLE
Ease rpm requirement to allow smooth installation

### DIFF
--- a/ovirt-cockpit-sso.spec
+++ b/ovirt-cockpit-sso.spec
@@ -14,11 +14,20 @@ Source0:        ovirt-cockpit-sso-%{version}.tar.gz
 
 BuildArch: noarch
 
-# None of the 4.2 features are reuiqred by this package but "Host Console" link is first introduced here
+# None of the 4.2 features are reuiqred by this package but "Host Console" link is introduced here for the first time
 Requires: ovirt-engine >= 4.2
 
+## TODO: increase to 140 once RHEL 7.5 is released
+## In fact, cockpit 140 is required but this is eased to allow smooth deployment for testing in the meantime
+## cockpit 140 is farther enforced in start.sh which is called by systemd
+%if 0%{?fedora} >= 26
+## fedora >26 is fine
 Requires: cockpit-ws >= 140
 Requires: cockpit-dashboard >= 140
+%else
+Requires: cockpit-ws >= 138
+Requires: cockpit-dashboard >= 138
+%endif
 
 %description
 This package sets cockpit-ws service (see cockpit-project.org) to provide SSO (Single Sign On) from oVirt's Administration Portal to Cockpit running on an oVirt's host machine.

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,24 @@
 #!/bin/sh -
 
-echo $$ > /var/run/ovirt-cockpit-sso/ovirt-cockpit-sso.pid
+COCKPIT_VERSION=`rpm -q --queryformat '%{VERSION}' cockpit-ws`
 
-# Add "G_MESSAGES_DEBUG=all" bellow to turn on debug messages in /var/log/messages
-OVIRT_FQDN=$(hostname -f) XDG_CONFIG_DIRS=/usr/share/ovirt-cockpit-sso/config /usr/libexec/cockpit-ws --port=9986
+echo Installed cockpit version: ${COCKPIT_VERSION}
+
+# TODO: Following if-clause will be removed once rhel 7.5 is released, see comment in .spec file
+if [ "$COCKPIT_VERSION" -ge 140 ] ; then
+    echo Cockpit version check passed
+
+    echo $$ > /var/run/ovirt-cockpit-sso/ovirt-cockpit-sso.pid
+
+    # Add "G_MESSAGES_DEBUG=all" bellow to turn on debug messages in /var/log/messages
+    OVIRT_FQDN=$(hostname -f) XDG_CONFIG_DIRS=/usr/share/ovirt-cockpit-sso/config /usr/libexec/cockpit-ws --port=9986
+else
+    # By skipping ovirt-cockpit-sso.pid here, the IsOvirtCockpitSSOStartedQuery check in engine will fail
+    logger Installed cockpit-ws version is ${COCKPIT_VERSION} but at least 140 is required. Cockpit-ovirt-sso will be effectively disabled.
+
+    # TODO: just for debugging:
+    echo Installed Cockpit version ${COCKPIT_VERSION} is old, at least 140 is required for ovirt-cockpit SSO
+
+    # Since SSO is disabled in this flow, do nothing but keep the service running
+    tail -f /dev/null
+fi


### PR DESCRIPTION
This commit is meant to be reverted once RHEL 7.5 is released.

In the meantime, it allows at least package installation so testing
is possible.

The package effectively requires cockpit-ws >= 140 but RHEL 7.4 comes
with 138 only. Fine for Fedora >= 26.

This commit eases requirement in the .spec file to 138 but effectively
disables the service in start.sh when cockpit-ws <=140 is detected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mareklibra/ovirt-cockpit-sso/6)
<!-- Reviewable:end -->
